### PR TITLE
--host parameter added to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ restic supports the following backends for storing backups natively:
 
 ## How to use this image
 
+restic  snapshots are tied to the hostname of your devices that is backed up. In case of using docker the host name is generate randomly every time you start the backup.
+Therefore it is important to use the `--host myHost` parameter. Otherwise Backups take much longer because the repository is scanned completely.
+
+
 Mount your data, specify your credentials, and provide the `restic` command you require:
 ```bash
 docker run --rm -v $(pwd):/data \
@@ -59,7 +63,7 @@ docker run --rm -v $(pwd):/data \
            -e RESTIC_PASSWORD=my-secure-password \
            -e AWS_ACCESS_KEY_ID=my-aws-access-key \
            -e AWS_SECRET_ACCESS_KEY=my-aws-secret-key \
-    instrumentisto/restic backup /data
+    instrumentisto/restic backup --host myHost /data
 ```
 
 
@@ -76,7 +80,7 @@ docker run --rm -v $(pwd):/data \
            -v rclone-config:/root/.config/rclone \
            -e RESTIC_REPOSITORY=rclone:rclone-respository-name:folder-path \
            -e RESTIC_PASSWORD=my-secure-password \
-       instrumentisto/restic backup /data
+       instrumentisto/restic backup --host myHost /data
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,6 @@ restic supports the following backends for storing backups natively:
 
 ## How to use this image
 
-restic  snapshots are tied to the hostname of your devices that is backed up. In case of using docker the host name is generate randomly every time you start the backup.
-Therefore it is important to use the `--host myHost` parameter. Otherwise Backups take much longer because the repository is scanned completely.
-
-
 Mount your data, specify your credentials, and provide the `restic` command you require:
 ```bash
 docker run --rm -v $(pwd):/data \
@@ -65,6 +61,8 @@ docker run --rm -v $(pwd):/data \
            -e AWS_SECRET_ACCESS_KEY=my-aws-secret-key \
     instrumentisto/restic backup --host myHost /data
 ```
+
+> __NOTE__: restic snapshots are tied to the hostname of your devices that are backed up. In case of using Docker, the host name is generate randomly every time you start a new container. Therefore, it's important to use the `--host myHost` parameter, otherwise the backups take much longer time, because the repository is scanned completely.
 
 
 ### With `rclone`


### PR DESCRIPTION
Hi,

after some time wandering why i had always a lot of different snapshots on my repo, i realized that the host name was different every time i did a backup. 
Therefor i added the `--host` parameter to the backup call. This way backups are way faster because restic finds a parent snapshot and does not scan the complete repo before backing up.
